### PR TITLE
Fix format string literal, backwards compatible with python3.4

### DIFF
--- a/src/task_forge/cli/__init__.py
+++ b/src/task_forge/cli/__init__.py
@@ -49,7 +49,7 @@ def print_lists():
         sys.exit(0)
 
     for name, _ in lists:
-        print(f'  {name}')
+        print('{}'.format(name))
 
 
 def main():

--- a/src/task_forge/cli/next_cmd.py
+++ b/src/task_forge/cli/next_cmd.py
@@ -33,4 +33,4 @@ def run(args, task_list=None):
     elif args['--id-only']:
         print(task.id)
     else:
-        print(f'{task.id}: {task.title}')
+        print('{}: {}'.format(task.id, task.title))

--- a/src/task_forge/task/__init__.py
+++ b/src/task_forge/task/__init__.py
@@ -46,7 +46,7 @@ class Note:
 
     def __repr__(self):
         """Return a simple string of note id and body."""
-        return f'Note({self.id})'
+        return '{}'.format(self.id)
 
     @classmethod
     def from_dict(cls, dictionary):
@@ -173,7 +173,7 @@ class Task:  # pylint: disable=too-many-instance-attributes
 
     def __repr__(self):
         """Return a simple string of the task id and title."""
-        return f'Task({self.id})'
+        return '{}'.format(self.id)
 
     @classmethod
     def from_dict(cls, dictionary):


### PR DESCRIPTION
From discussion in [#11](https://github.com/chasinglogic/taskforge/issues/11)

 