### PR TITLE
README: add travis-ci/pypi/license badges (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Build Status](https://travis-ci.org/chasinglogic/taskforge.svg?branch=master)](https://travis-ci.org/chasinglogic/taskforge)
+[![PyPI package](https://img.shields.io/pypi/v/taskforge-cli.svg)](https://pypi.python.org/pypi/taskforge-cli/)
+[![Python versions](https://img.shields.io/pypi/pyversions/taskforge-cli.svg)](https://pypi.python.org/pypi/taskforge-cli/)
+[![GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/chasinglogic/taskforge/blob/master/LICENSE)
+[![Docs](https://img.shields.io/badge/docs-passing-green.svg)](http://taskforge.io/docs/)
+
 ![Taskforge](https://raw.githubusercontent.com/chasinglogic/taskforge/master/src/docs/_static/logo_wide.png)
 
 Task management tool and library that integrates and aggregates other services.


### PR DESCRIPTION
When the license is fixed on PyPI (showing AGPL as of 2018-10-17), use
the following link instead:

  https://img.shields.io/pypi/l/taskforge-cli.svg

If/when readthedocs is available, use the following link instead:

  https://readthedocs.org/projects/taskforge-cli/badge/